### PR TITLE
hammerhead: Disable thread boosting

### DIFF
--- a/init.hammerhead.rc
+++ b/init.hammerhead.rc
@@ -221,7 +221,7 @@ on post-fs-data
     write /sys/devices/system/cpu/cpufreq/interactive/timer_slack 30000
 
     # cpu-boost
-    write /sys/module/cpu_boost/parameters/boost_ms 20
+    # write /sys/module/cpu_boost/parameters/boost_ms 20
     write /sys/module/cpu_boost/parameters/sync_threshold 1728000
     write /sys/module/cpu_boost/parameters/input_boost_freq 1190400
     write /sys/module/cpu_boost/parameters/input_boost_ms 500


### PR DESCRIPTION
This gives significant savings, especially during video playback.

Change-Id: Ia1fe66a76f967cde7498ef24f245714f5206d8c8